### PR TITLE
Fix maven delimiters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.github.britter</groupId>
     <artifactId>spring-boot-heroku-demo</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,3 @@
-git.commit.hash=${buildNumber}
-git.commit.link=${git.commit.link}
-project.version=${project.version}
+git.commit.hash=@buildNumber@
+git.commit.link=@git.commit.link@
+project.version=@project.version@


### PR DESCRIPTION
Use '@' as resource filtering delimiter.

This was introduced by spring-boot-maven-plugin in 1.3.0.RELEASE to make sure maven will not replace Spring EL expressions. For more information see:
- spring-projects/spring-boot#4920
- [Spring Boot 1.3 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.3-Release-Notes#maven-resources-filtering)
